### PR TITLE
Add animated timeline to experiences page

### DIFF
--- a/src/components/experiences/experience.jsx
+++ b/src/components/experiences/experience.jsx
@@ -1,36 +1,63 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
+import { faChevronRight, faBriefcase, faGraduationCap } from "@fortawesome/free-solid-svg-icons";
 
 import "./style/experience.css";
 
 const Experience = (props) => {
-	const { date, title, description, link } = props;
+       const { date, title, description, link, type } = props;
+       const ref = useRef(null);
 
-	return (
-		<React.Fragment>
-			<div className="experience">
-				<div className="experience-left-side">
-					<div className="experience-date">{date}</div>
-				</div>
+       useEffect(() => {
+               const observer = new IntersectionObserver(
+                       (entries) => {
+                               entries.forEach((entry) => {
+                                       if (entry.isIntersecting) {
+                                               entry.target.classList.add("show");
+                                               observer.unobserve(entry.target);
+                                       }
+                               });
+                       },
+                       { threshold: 0.1 }
+               );
 
-				<Link to={link}>
-					<div className="experience-right-side">
-						<div className="experience-title">{title}</div>
-						<div className="experience-description">{description}</div>
-						<div className="experience-link">
-							Read Experience{" "}
-							<FontAwesomeIcon
-								style={{ fontSize: "10px" }}
-								icon={faChevronRight}
-							/>
-						</div>
-					</div>
-				</Link>
-			</div>
-		</React.Fragment>
-	);
+               if (ref.current) {
+                       observer.observe(ref.current);
+               }
+
+               return () => observer.disconnect();
+       }, []);
+
+       return (
+               <React.Fragment>
+                       <div ref={ref} className={`experience ${type}`}>
+                               <div className={`experience-left-side ${type}`}> 
+                                       <div className="experience-marker">
+                                               <FontAwesomeIcon
+                                                       icon={type === "education" ? faGraduationCap : faBriefcase}
+                                                       className="experience-icon"
+                                               />
+                                       </div>
+                                       <div className="experience-date">{date}</div>
+                               </div>
+
+                               <Link to={link}>
+                                       <div className="experience-right-side">
+                                               <div className="experience-title">{title}</div>
+                                               <div className="experience-description">{description}</div>
+                                               <div className="experience-link">
+                                                       Read Experience{" "}
+                                                       <FontAwesomeIcon
+                                                               style={{ fontSize: "10px" }}
+                                                               icon={faChevronRight}
+                                                       />
+                                               </div>
+                                       </div>
+                               </Link>
+                       </div>
+               </React.Fragment>
+       );
 };
 
 export default Experience;

--- a/src/components/experiences/style/experience.css
+++ b/src/components/experiences/style/experience.css
@@ -1,7 +1,16 @@
 @import "../../../data/styles.css";
 
 .experience {
-	display: flex;
+       display: flex;
+       opacity: 0;
+       transform: translateY(20px);
+       transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+       position: relative;
+}
+
+.experience.show {
+       opacity: 1;
+       transform: translateY(0);
 }
 
 .experience a {
@@ -9,8 +18,37 @@
 }
 
 .experience-left-side {
-	min-width: 20%;
-	max-width: 20%;
+       min-width: 20%;
+       max-width: 20%;
+       display: flex;
+       flex-direction: column;
+       align-items: center;
+}
+
+.experience-marker {
+       width: 24px;
+       height: 24px;
+       border-radius: 50%;
+       display: flex;
+       align-items: center;
+       justify-content: center;
+       color: #ffffff;
+       margin-bottom: 5px;
+       position: absolute;
+       left: -49px;
+       top: 25px;
+}
+
+.experience-icon {
+       font-size: 12px;
+}
+
+.experience-left-side.education .experience-marker {
+       background-color: #4f46e5;
+}
+
+.experience-left-side.work .experience-marker {
+       background-color: #e11d48;
 }
 
 .experience-right-side {

--- a/src/data/experiences.js
+++ b/src/data/experiences.js
@@ -1,10 +1,11 @@
 import React from "react";
 
 function experience_1() {
-	return {
-		date: "2021 - 2022",
-		title: "Kav Mashve - Webahead",
-		description: "Intensive JavaScript Full Stack Coding Bootcamp ",
+        return {
+                date: "2021 - 2022",
+                title: "Kav Mashve - Webahead",
+                description: "Intensive JavaScript Full Stack Coding Bootcamp ",
+                type: "education",
 		keywords: [
 			"The Benefits of Cloud Computing",
 			"Julio",
@@ -37,10 +38,11 @@ function experience_1() {
 }
 
 function experience_2() {
-	return {
-		date: "2023 - PRESENT",
-		title: "Shenkar College",
-		description: "Bachelor of Software Engineer & Game Design Student",
+        return {
+                date: "2023 - PRESENT",
+                title: "Shenkar College",
+                description: "Bachelor of Software Engineer & Game Design Student",
+                type: "education",
 		style: ``,
 		keywords: [
 			"Artificial Intelligence in Healthcare",
@@ -60,10 +62,11 @@ function experience_2() {
 }
 
 function experience_3() {
-	return {
-		date: "2022 - 2023",
-		title: "GrayMatters Health",
-		description: "Front End Developer",
+        return {
+                date: "2022 - 2023",
+                title: "GrayMatters Health",
+                description: "Front End Developer",
+                type: "work",
 		style: ``,
 		keywords: [
 			"Artificial Intelligence in Healthcare",

--- a/src/pages/experiences.jsx
+++ b/src/pages/experiences.jsx
@@ -50,22 +50,23 @@ const Experiences = () => {
 
 						<div className="experiences-container">
 							<div className="experiences-wrapper">
-								{myExperiences.map((experience, index) => (
-									<div
-										className="experiences-experience"
-										key={(index + 1).toString()}
-									>
-										<Experience
-											key={(index + 1).toString()}
-											date={experience().date}
-											title={experience().title}
-											description={experience().description}
-											link={"/experience/" + (index + 1)}
-										/>
-									</div>
-								))}
-							</div>
-						</div>
+                                                               {myExperiences.map((experience, index) => (
+                                                                        <div
+                                                                               className="experiences-experience"
+                                                                               key={(index + 1).toString()}
+                                                                        >
+                                                                               <Experience
+                                                                                       key={(index + 1).toString()}
+                                                                                       date={experience().date}
+                                                                                       title={experience().title}
+                                                                                       description={experience().description}
+                                                                                       link={"/experience/" + (index + 1)}
+                                                                                       type={experience().type}
+                                                                               />
+                                                                        </div>
+                                                               ))}
+                                                       </div>
+                                               </div>
 					</div>
 					<div className="page-footer">
 						<Footer />

--- a/src/pages/styles/experiences.css
+++ b/src/pages/styles/experiences.css
@@ -33,11 +33,12 @@
 }
 
 .experiences-experience {
-	padding-top: 0px;
-	padding-left: 35px;
-	padding-bottom: 20px;
-	border-left: 2px solid #f4f4f5;
-	width: 100%;
+       padding-top: 0px;
+       padding-left: 35px;
+       padding-bottom: 20px;
+       border-left: 2px solid #f4f4f5;
+       width: 100%;
+       position: relative;
 }
 
 @media (max-width: 1024px) {


### PR DESCRIPTION
## Summary
- support education/work type in experience data
- animate experience cards on scroll
- color-code education vs work markers
- display icons on experience timeline items

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68606e3e6c2c8325b1715b312a5d55ec