### PR TITLE
Add interactive skill grid

### DIFF
--- a/src/components/about/skillGrid.jsx
+++ b/src/components/about/skillGrid.jsx
@@ -1,0 +1,64 @@
+import React, { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+    faReact,
+    faJs,
+    faNodeJs,
+    faHtml5,
+    faCss3Alt,
+    faGitAlt,
+} from "@fortawesome/free-brands-svg-icons";
+import { faDatabase } from "@fortawesome/free-solid-svg-icons";
+
+import "./styles/skillGrid.css";
+
+const skills = [
+    { icon: faReact, name: "React" },
+    { icon: faJs, name: "JavaScript" },
+    { icon: faNodeJs, name: "Node" },
+    { icon: faHtml5, name: "HTML" },
+    { icon: faCss3Alt, name: "CSS" },
+    { icon: faDatabase, name: "SQL" },
+    { icon: faGitAlt, name: "Git" },
+];
+
+const SkillGrid = () => {
+    const [unlocked, setUnlocked] = useState(Array(skills.length).fill(false));
+
+    const handleUnlock = (index) => {
+        setUnlocked((prev) => {
+            const updated = [...prev];
+            updated[index] = true;
+            return updated;
+        });
+    };
+
+    const resetGrid = () => {
+        setUnlocked(Array(skills.length).fill(false));
+    };
+
+    return (
+        <div className="skill-grid-wrapper">
+            <div className="skill-grid">
+                {skills.map((skill, index) => (
+                    <div
+                        key={index}
+                        className={`skill-tile ${unlocked[index] ? "unlocked" : ""}`}
+                        onMouseEnter={() => handleUnlock(index)}
+                        onClick={() => handleUnlock(index)}
+                    >
+                        <FontAwesomeIcon icon={skill.icon} className="skill-icon" />
+                        {unlocked[index] && <span className="skill-xp">+XP</span>}
+                    </div>
+                ))}
+            </div>
+            <div className="skill-reset-wrapper">
+                <button className="skill-reset" onClick={resetGrid}>
+                    Reset
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default SkillGrid;

--- a/src/components/about/styles/skillGrid.css
+++ b/src/components/about/styles/skillGrid.css
@@ -1,0 +1,63 @@
+@import "../../../data/styles.css";
+
+.skill-grid-wrapper {
+    padding-top: 40px;
+    text-align: center;
+}
+
+.skill-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+    gap: 20px;
+    justify-items: center;
+}
+
+.skill-tile {
+    width: 80px;
+    height: 80px;
+    border-radius: 10px;
+    background-color: var(--quaternary-color);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    filter: grayscale(100%);
+    transition: transform 0.3s, box-shadow 0.3s, filter 0.3s;
+}
+
+.skill-tile.unlocked {
+    filter: none;
+    box-shadow: 0 0 10px var(--link-color);
+    transform: scale(1.1);
+}
+
+.skill-icon {
+    font-size: 30px;
+    color: var(--secondary-color);
+}
+
+.skill-xp {
+    position: absolute;
+    bottom: -15px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 12px;
+    color: var(--link-color);
+}
+
+.skill-reset-wrapper {
+    margin-top: 20px;
+}
+
+.skill-reset {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 5px;
+    background-color: var(--primary-color);
+    color: #fff;
+    cursor: pointer;
+}
+
+.skill-reset:hover {
+    background-color: var(--secondary-color);
+}

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -5,6 +5,7 @@ import NavBar from "../components/common/navBar";
 import Footer from "../components/common/footer";
 import Logo from "../components/common/logo";
 import Socials from "../components/about/socials";
+import SkillGrid from "../components/about/skillGrid";
 
 import INFO from "../data/user";
 import SEO from "../data/seo";
@@ -66,10 +67,11 @@ const About = () => {
 								</div>
 							</div>
 						</div>
-						<div className="about-socials-mobile">
-							<Socials />
-						</div>
-					</div>
+                                                <div className="about-socials-mobile">
+                                                        <Socials />
+                                                </div>
+                                                <SkillGrid />
+                                        </div>
 					<div className="page-footer">
 						<Footer />
 					</div>


### PR DESCRIPTION
## Summary
- create `SkillGrid` component for interactive skill icons
- style grid with animations for unlocking
- place skill grid on the About page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860764aee1483259020e2baa230eb0a