### PR TITLE
Transform skill grid into memory game

### DIFF
--- a/src/components/about/styles/skillGrid.css
+++ b/src/components/about/styles/skillGrid.css
@@ -20,37 +20,29 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    position: relative;
-    filter: grayscale(100%);
-    transition: transform 0.3s, box-shadow 0.3s, filter 0.3s;
-}
-
-.skill-tile.unlocked {
-    filter: none;
-    box-shadow: 0 0 10px var(--link-color);
-    transform: scale(1.1);
-}
-
-.skill-icon {
     font-size: 30px;
+    color: var(--secondary-color);
+    cursor: pointer;
+}
+
+.skill-tile.flipped,
+.skill-tile.matched {
+    background-color: var(--primary-color);
     color: var(--secondary-color);
 }
 
-.skill-xp {
-    position: absolute;
-    bottom: -15px;
-    left: 50%;
-    transform: translateX(-50%);
-    font-size: 12px;
-    color: var(--link-color);
+.hidden-icon {
+    font-size: 24px;
 }
 
 .skill-reset-wrapper {
     margin-top: 20px;
 }
 
-.skill-reset {
+.skill-reset,
+.skill-auto {
     padding: 8px 16px;
+    margin: 0 5px;
     border: none;
     border-radius: 5px;
     background-color: var(--primary-color);
@@ -58,6 +50,7 @@
     cursor: pointer;
 }
 
-.skill-reset:hover {
-    background-color: var(--secondary-color);
+.skill-auto:disabled {
+    background-color: var(--tertiary-color);
+    cursor: default;
 }

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -41,15 +41,17 @@ const About = () => {
 
 					<div className="about-container">
 						<div className="about-main">
-							<div className="about-right-side">
-								<div className="title about-title">
-									{INFO.about.title}
-								</div>
+                                                <div className="about-right-side">
+                                                        <div className="title about-title">
+                                                                {INFO.about.title}
+                                                        </div>
 
-								<div className="subtitle about-subtitle">
-									{INFO.about.description}
-								</div>
-							</div>
+                                                        <div className="subtitle about-subtitle">
+                                                                {INFO.about.description}
+                                                        </div>
+
+                                                        <SkillGrid />
+                                                </div>
 
 							<div className="about-left-side">
 								<div className="about-image-container">
@@ -70,7 +72,6 @@ const About = () => {
                                                 <div className="about-socials-mobile">
                                                         <Socials />
                                                 </div>
-                                                <SkillGrid />
                                         </div>
 					<div className="page-footer">
 						<Footer />

--- a/src/pages/styles/about.css
+++ b/src/pages/styles/about.css
@@ -25,7 +25,9 @@
 }
 
 .about-right-side {
-	flex-basis: 900px;
+        flex-basis: 900px;
+        display: flex;
+        flex-direction: column;
 }
 
 .about-title {


### PR DESCRIPTION
## Summary
- reposition SkillGrid inside the about right side container
- gamify SkillGrid as a memory matching game
- style SkillGrid for flipping and add auto-finish button

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686078705cc88325a5bfdd8856eb2523