### PR TITLE
Combine matched skill tiles

### DIFF
--- a/src/components/about/skillGrid.jsx
+++ b/src/components/about/skillGrid.jsx
@@ -39,6 +39,8 @@ const generateCards = () => {
         id: idx,
         isFlipped: false,
         isMatched: false,
+        showName: false,
+        isRemoved: false,
     }));
 };
 
@@ -65,7 +67,9 @@ const SkillGrid = () => {
                 setCards((prev) => {
                     const updated = [...prev];
                     updated[first].isMatched = true;
+                    updated[first].showName = true;
                     updated[second].isMatched = true;
+                    updated[second].isRemoved = true;
                     return updated;
                 });
                 setFlipped([]);
@@ -85,16 +89,26 @@ const SkillGrid = () => {
         }
     }, [flipped, cards]);
 
-    const resetGrid = () => {
-        setCards(generateCards());
-        setFlipped([]);
-        setDisabled(false);
-    };
+const resetGrid = () => {
+    setCards(generateCards());
+    setFlipped([]);
+    setDisabled(false);
+};
 
-    const autoFinish = () => {
-        setCards((prev) => prev.map((c) => ({ ...c, isFlipped: true, isMatched: true })));
-        setFlipped([]);
-    };
+const autoFinish = () => {
+    setCards((prev) => {
+        const seen = {};
+        return prev.map((c) => {
+            if (seen[c.name]) {
+                return { ...c, isFlipped: true, isMatched: true, isRemoved: true };
+            } else {
+                seen[c.name] = true;
+                return { ...c, isFlipped: true, isMatched: true, showName: true };
+            }
+        });
+    });
+    setFlipped([]);
+};
 
     const solved = cards.every((c) => c.isMatched);
 
@@ -102,17 +116,22 @@ const SkillGrid = () => {
         <div className="skill-grid-wrapper">
             <div className="skill-grid">
                 {cards.map((card, index) => (
-                    <div
-                        key={card.id}
-                        className={`skill-tile ${card.isFlipped || card.isMatched ? "flipped" : ""} ${card.isMatched ? "matched" : ""}`}
-                        onClick={() => handleCardClick(index)}
-                    >
-                        {card.isFlipped || card.isMatched ? (
-                            <FontAwesomeIcon icon={card.icon} className="skill-icon" />
-                        ) : (
-                            <span className="hidden-icon">?</span>
-                        )}
-                    </div>
+                    card.isRemoved ? null : (
+                        <div
+                            key={card.id}
+                            className={`skill-tile ${card.isFlipped || card.isMatched ? "flipped" : ""} ${card.isMatched ? "matched" : ""}`}
+                            onClick={() => handleCardClick(index)}
+                        >
+                            {card.isFlipped || card.isMatched ? (
+                                <>
+                                    <FontAwesomeIcon icon={card.icon} className="skill-icon" />
+                                    {card.showName && <div className="skill-name">{card.name}</div>}
+                                </>
+                            ) : (
+                                <span className="hidden-icon">?</span>
+                            )}
+                        </div>
+                    )
                 ))}
             </div>
             <div className="skill-reset-wrapper">

--- a/src/components/about/styles/skillGrid.css
+++ b/src/components/about/styles/skillGrid.css
@@ -35,6 +35,11 @@
     font-size: 24px;
 }
 
+.skill-name {
+    font-size: 12px;
+    margin-top: 4px;
+}
+
 .skill-reset-wrapper {
     margin-top: 20px;
 }


### PR DESCRIPTION
## Summary
- update skill matching game logic so matching cards collapse into a single tile and show the skill name
- update auto finish to collapse duplicates
- add styles for skill name

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68607aeb44b883259cb30e068d2f957d