### PR TITLE
Update skill grid text alignment

### DIFF
--- a/src/components/about/styles/skillGrid.css
+++ b/src/components/about/styles/skillGrid.css
@@ -18,6 +18,7 @@
     border-radius: 10px;
     background-color: var(--quaternary-color);
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
     font-size: 30px;
@@ -28,7 +29,7 @@
 .skill-tile.flipped,
 .skill-tile.matched {
     background-color: var(--primary-color);
-    color: var(--secondary-color);
+    color: var(--quaternary-color);
 }
 
 .hidden-icon {
@@ -38,6 +39,7 @@
 .skill-name {
     font-size: 12px;
     margin-top: 4px;
+    color: inherit;
 }
 
 .skill-reset-wrapper {

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -46,11 +46,13 @@ const About = () => {
                                                                 {INFO.about.title}
                                                         </div>
 
-                                                        <div className="subtitle about-subtitle">
-                                                                {INFO.about.description}
-                                                        </div>
+                                                       <div className="subtitle about-subtitle">
+                                                               {INFO.about.description}
+                                                       </div>
 
-                                                        <SkillGrid />
+                                                       <div className="title skill-grid-title">Skill Memory Game</div>
+
+                                                       <SkillGrid />
                                                 </div>
 
 							<div className="about-left-side">

--- a/src/pages/styles/about.css
+++ b/src/pages/styles/about.css
@@ -36,7 +36,12 @@
 }
 
 .about-subtitle {
-	width: 80% !important;
+        width: 80% !important;
+}
+
+.skill-grid-title {
+        width: 80% !important;
+        margin-top: 30px;
 }
 
 .about-left-side {


### PR DESCRIPTION
## Summary
- stack skill labels under their icons in the memory game
- add a heading for the skill grid on the About page
- brighten flipped skill tiles

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68607d22ff3c83259e5a8ccf6d5cf3b2