### PR TITLE
Add locked overlay for homepage cards

### DIFF
--- a/src/components/homepage/experience.jsx
+++ b/src/components/homepage/experience.jsx
@@ -2,17 +2,18 @@ import React from "react";
 import { Link } from "react-router-dom";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faChevronRight } from "@fortawesome/free-solid-svg-icons";
+import { faChevronRight, faLock } from "@fortawesome/free-solid-svg-icons";
 
 import "./styles/experience.css";
 
 const Experience = (props) => {
-	const { title, description, date, link } = props;
+        const { title, description, date, link, locked } = props;
 
 	return (
 		<React.Fragment>
-			<div className="homepage-experience">
-				<div className="homepage-experience-content">
+                        <div className="homepage-experience-wrapper">
+                                <div className={`homepage-experience${locked ? " locked" : ""}`}>
+                                        <div className="homepage-experience-content">
 					<div className="homepage-experience-date">
 						|&nbsp;&nbsp;&nbsp;{date}
 					</div>
@@ -21,15 +22,21 @@ const Experience = (props) => {
 						{description}
 					</div>
 					<div className="homepage-experience-link">
-						<Link to={link}>
-							Read experience{" "}
-							<FontAwesomeIcon
-								style={{ fontSize: "10px" }}
-								icon={faChevronRight}
-							/>
-						</Link>
-					</div>
-				</div>
+                                                <Link to={link} className="homepage-experience-link-anchor">
+                                                        Read experience{" "}
+                                                        <FontAwesomeIcon
+                                                                style={{ fontSize: "10px" }}
+                                                                icon={faChevronRight}
+                                                        />
+                                                </Link>
+                                        </div>
+                                </div>
+                                {locked && (
+                                        <div className="locked-overlay">
+                                                <FontAwesomeIcon icon={faLock} className="lock-icon" />
+                                        </div>
+                                )}
+                        </div>
 			</div>
 		</React.Fragment>
 	);

--- a/src/components/homepage/styles/experience.css
+++ b/src/components/homepage/styles/experience.css
@@ -9,6 +9,10 @@
         min-width: 250px;
 }
 
+.homepage-experience-wrapper {
+        position: relative;
+}
+
 .homepage-experience:hover {
 	background: #fafafa;
 	opacity: 1;
@@ -49,8 +53,32 @@
 }
 
 .homepage-experience-link a {
-	color: var(--link-color);
-	text-decoration: none;
+        color: var(--link-color);
+        text-decoration: none;
+}
+
+.homepage-experience.locked {
+        pointer-events: none;
+        filter: grayscale(100%);
+}
+
+.locked-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.6);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        border-radius: 20px;
+        z-index: 5;
+        color: #fff;
+}
+
+.lock-icon {
+        font-size: 24px;
 }
 
 @media (max-width: 600px) {

--- a/src/components/projects/allProjects.jsx
+++ b/src/components/projects/allProjects.jsx
@@ -6,7 +6,7 @@ import INFO from "../../data/user";
 
 import "./styles/allProjects.css";
 
-const AllProjects = () => {
+const AllProjects = ({ locked }) => {
 	return (
 		<div className="all-projects-container">
 			{INFO.projects.map((project, index) => (
@@ -18,6 +18,7 @@ const AllProjects = () => {
                                                stack={project.stack}
                                                linkText={project.linkText}
                                                link={project.link}
+                                               locked={locked}
                                        />
 				</div>
 			))}

--- a/src/components/projects/project.jsx
+++ b/src/components/projects/project.jsx
@@ -1,38 +1,45 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faLink } from "@fortawesome/free-solid-svg-icons";
+import { faLink, faLock } from "@fortawesome/free-solid-svg-icons";
 
 import "./styles/project.css";
 
 const Project = (props) => {
-       const { logo, title, description, stack, linkText, link } = props;
+       const { logo, title, description, stack, linkText, link, locked } = props;
 
-	return (
-		<React.Fragment>
-			<div className="project">
-				<Link to={link}>
-					<div className="project-container">
-						<div className="project-logo">
-							<img src={logo} alt="logo" />
-						</div>
-						<div className="project-title">{title}</div>
+        return (
+                <React.Fragment>
+                        <div className="project-wrapper">
+                                <div className={`project${locked ? " locked" : ""}`}>
+                                        <Link to={link} className="project-link-anchor">
+                                                <div className="project-container">
+                                                <div className="project-logo">
+                                                        <img src={logo} alt="logo" />
+                                                </div>
+                                                <div className="project-title">{title}</div>
                                                <div className="project-description">{description}</div>
                                                {stack && (
                                                        <div className="project-stack">{stack}</div>
                                                )}
                                                <div className="project-link">
-							<div className="project-link-icon">
-								<FontAwesomeIcon icon={faLink} />
-							</div>
+                                                        <div className="project-link-icon">
+                                                                <FontAwesomeIcon icon={faLink} />
+                                                        </div>
 
-							<div className="project-link-text">{linkText}</div>
-						</div>
-					</div>
-				</Link>
-			</div>
-		</React.Fragment>
-	);
+                                                        <div className="project-link-text">{linkText}</div>
+                                                </div>
+                                                </div>
+                                        </Link>
+                                </div>
+                                {locked && (
+                                        <div className="locked-overlay">
+                                                <FontAwesomeIcon icon={faLock} className="lock-icon" />
+                                        </div>
+                                )}
+                        </div>
+                </React.Fragment>
+        );
 };
 
 export default Project;

--- a/src/components/projects/styles/project.css
+++ b/src/components/projects/styles/project.css
@@ -1,10 +1,14 @@
 @import "../../../data/styles.css";
 
 .project {
-	mix-blend-mode: normal;
-	border-radius: 20px;
-	opacity: 0.8;
-	height: 100%;
+        mix-blend-mode: normal;
+        border-radius: 20px;
+        opacity: 0.8;
+        height: 100%;
+}
+
+.project-wrapper {
+        position: relative;
 }
 
 .project a {
@@ -67,8 +71,32 @@
 }
 
 .project-link-text {
-	padding-left: 20px;
-	font-weight: 700;
+        padding-left: 20px;
+        font-weight: 700;
+}
+
+.project.locked {
+        pointer-events: none;
+        filter: grayscale(100%);
+}
+
+.locked-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.6);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        border-radius: 20px;
+        z-index: 5;
+        color: #fff;
+}
+
+.lock-icon {
+        font-size: 24px;
 }
 
 @media (max-width: 600px) {

--- a/src/pages/experiences.jsx
+++ b/src/pages/experiences.jsx
@@ -13,9 +13,10 @@ import myExperiences from "../data/experiences";
 import "./styles/experiences.css";
 
 const Experiences = () => {
-	useEffect(() => {
-		window.scrollTo(0, 0);
-	}, []);
+        useEffect(() => {
+                window.scrollTo(0, 0);
+                localStorage.setItem("visitedExperiences", "true");
+        }, []);
 
 	const currentSEO = SEO.find((item) => item.page === "experiences");
 

--- a/src/pages/homepage.jsx
+++ b/src/pages/homepage.jsx
@@ -21,13 +21,20 @@ import myExperiences from "../data/experiences";
 import "./styles/homepage.css";
 
 const Homepage = () => {
-	const [stayLogo, setStayLogo] = useState(false);
-	const [logoSize, setLogoSize] = useState(80);
-	const [oldLogoSize, setOldLogoSize] = useState(80);
+        const [stayLogo, setStayLogo] = useState(false);
+        const [logoSize, setLogoSize] = useState(80);
+        const [oldLogoSize, setOldLogoSize] = useState(80);
+        const [projectsUnlocked, setProjectsUnlocked] = useState(false);
+        const [experiencesUnlocked, setExperiencesUnlocked] = useState(false);
 
-	useEffect(() => {
-		window.scrollTo(0, 0);
-	}, []);
+        useEffect(() => {
+                window.scrollTo(0, 0);
+        }, []);
+
+        useEffect(() => {
+                setProjectsUnlocked(localStorage.getItem("visitedProjects") === "true");
+                setExperiencesUnlocked(localStorage.getItem("visitedExperiences") === "true");
+        }, []);
 
 	useEffect(() => {
 		const handleScroll = () => {
@@ -136,9 +143,9 @@ const Homepage = () => {
                                                         </div>
                                                 </div>
 
-						<div className="homepage-projects">
-							<AllProjects />
-						</div>
+                                                <div className="homepage-projects">
+                                                        <AllProjects locked={!projectsUnlocked} />
+                                                </div>
 
 						<div className="homepage-after-title">
 							<div className="homepage-experiences">
@@ -147,13 +154,13 @@ const Homepage = () => {
 										className="homepage-experience"
 										key={(index + 1).toString()}
 									>
-										<Experience
-											key={(index + 1).toString()}
-											date={experience().date}
-											title={experience().title}
-											description={experience().description}
-											link={"/experience/" + (index + 1)}
-										/>
+                                                                       <Experience
+                                                                               locked={!experiencesUnlocked}
+                                                                               date={experience().date}
+                                                                               title={experience().title}
+                                                                               description={experience().description}
+                                                                               link={"/experience/" + (index + 1)}
+                                                                              />
 									</div>
 								))}
 							</div>

--- a/src/pages/projects.jsx
+++ b/src/pages/projects.jsx
@@ -12,9 +12,10 @@ import SEO from "../data/seo";
 import "./styles/projects.css";
 
 const Projects = () => {
-	useEffect(() => {
-		window.scrollTo(0, 0);
-	}, []);
+        useEffect(() => {
+                window.scrollTo(0, 0);
+                localStorage.setItem("visitedProjects", "true");
+        }, []);
 
 	const currentSEO = SEO.find((item) => item.page === "projects");
 


### PR DESCRIPTION
## Summary
- block project and experience cards on the homepage until the relevant page has been visited
- add localStorage tracking for visited pages
- style locked cards with overlay and lock icon

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686087e9ca7c8325886597b9c277556f