### PR TITLE
Improve locked content overlay with instructions

### DIFF
--- a/src/components/homepage/experience.jsx
+++ b/src/components/homepage/experience.jsx
@@ -7,7 +7,7 @@ import { faChevronRight, faLock } from "@fortawesome/free-solid-svg-icons";
 import "./styles/experience.css";
 
 const Experience = (props) => {
-        const { title, description, date, link, locked } = props;
+        const { title, description, date, link, locked, unlockMessage } = props;
 
 	return (
 		<React.Fragment>
@@ -34,12 +34,15 @@ const Experience = (props) => {
                                 {locked && (
                                         <div className="locked-overlay">
                                                 <FontAwesomeIcon icon={faLock} className="lock-icon" />
+                                                {unlockMessage && (
+                                                        <div className="locked-text">{unlockMessage}</div>
+                                                )}
                                         </div>
                                 )}
                         </div>
-			</div>
-		</React.Fragment>
-	);
+                        </div>
+                </React.Fragment>
+        );
 };
 
 export default Experience;

--- a/src/components/homepage/styles/experience.css
+++ b/src/components/homepage/styles/experience.css
@@ -59,7 +59,7 @@
 
 .homepage-experience.locked {
         pointer-events: none;
-        filter: grayscale(100%);
+        filter: grayscale(100%) blur(3px);
 }
 
 .locked-overlay {
@@ -70,6 +70,7 @@
         height: 100%;
         background: rgba(0, 0, 0, 0.6);
         display: flex;
+        flex-direction: column;
         justify-content: center;
         align-items: center;
         border-radius: 20px;
@@ -79,6 +80,12 @@
 
 .lock-icon {
         font-size: 24px;
+}
+
+.locked-text {
+        margin-top: 8px;
+        text-align: center;
+        font-size: 12px;
 }
 
 @media (max-width: 600px) {

--- a/src/components/projects/allProjects.jsx
+++ b/src/components/projects/allProjects.jsx
@@ -7,10 +7,11 @@ import INFO from "../../data/user";
 import "./styles/allProjects.css";
 
 const AllProjects = ({ locked }) => {
-	return (
-		<div className="all-projects-container">
-			{INFO.projects.map((project, index) => (
-				<div className="all-projects-project" key={index}>
+        const message = "Visit the Projects page to unlock";
+        return (
+                <div className="all-projects-container">
+                        {INFO.projects.map((project, index) => (
+                                <div className="all-projects-project" key={index}>
                                        <Project
                                                logo={project.logo}
                                                title={project.title}
@@ -19,11 +20,12 @@ const AllProjects = ({ locked }) => {
                                                linkText={project.linkText}
                                                link={project.link}
                                                locked={locked}
+                                               unlockMessage={locked ? message : null}
                                        />
-				</div>
-			))}
-		</div>
-	);
+                                </div>
+                        ))}
+                </div>
+        );
 };
 
 export default AllProjects;

--- a/src/components/projects/project.jsx
+++ b/src/components/projects/project.jsx
@@ -6,7 +6,7 @@ import { faLink, faLock } from "@fortawesome/free-solid-svg-icons";
 import "./styles/project.css";
 
 const Project = (props) => {
-       const { logo, title, description, stack, linkText, link, locked } = props;
+       const { logo, title, description, stack, linkText, link, locked, unlockMessage } = props;
 
         return (
                 <React.Fragment>
@@ -35,6 +35,9 @@ const Project = (props) => {
                                 {locked && (
                                         <div className="locked-overlay">
                                                 <FontAwesomeIcon icon={faLock} className="lock-icon" />
+                                                {unlockMessage && (
+                                                        <div className="locked-text">{unlockMessage}</div>
+                                                )}
                                         </div>
                                 )}
                         </div>

--- a/src/components/projects/styles/project.css
+++ b/src/components/projects/styles/project.css
@@ -77,7 +77,7 @@
 
 .project.locked {
         pointer-events: none;
-        filter: grayscale(100%);
+        filter: grayscale(100%) blur(3px);
 }
 
 .locked-overlay {
@@ -88,6 +88,7 @@
         height: 100%;
         background: rgba(0, 0, 0, 0.6);
         display: flex;
+        flex-direction: column;
         justify-content: center;
         align-items: center;
         border-radius: 20px;
@@ -97,6 +98,12 @@
 
 .lock-icon {
         font-size: 24px;
+}
+
+.locked-text {
+        margin-top: 8px;
+        text-align: center;
+        font-size: 12px;
 }
 
 @media (max-width: 600px) {

--- a/src/pages/homepage.jsx
+++ b/src/pages/homepage.jsx
@@ -152,14 +152,15 @@ const Homepage = () => {
 									>
                                                                        <Experience
                                                                                locked={!experiencesUnlocked}
+                                                                               unlockMessage="Visit the Experiences page to unlock"
                                                                                date={experience().date}
                                                                                title={experience().title}
                                                                                description={experience().description}
                                                                                link={"/experience/" + (index + 1)}
                                                                               />
-									</div>
-								))}
-							</div>
+                                                                       </div>
+                                                               ))}
+                                                       </div>
 
 						</div>
 


### PR DESCRIPTION
## Summary
- add `unlockMessage` prop to homepage Experience and Project cards
- display unlock instructions on lock overlay
- blur text when locked

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608f48c2148325bcfce7086b9f4627