### PR TITLE
Reset project locks every tab

### DIFF
--- a/src/pages/experiences.jsx
+++ b/src/pages/experiences.jsx
@@ -13,10 +13,10 @@ import myExperiences from "../data/experiences";
 import "./styles/experiences.css";
 
 const Experiences = () => {
-        useEffect(() => {
-                window.scrollTo(0, 0);
-                localStorage.setItem("visitedExperiences", "true");
-        }, []);
+       useEffect(() => {
+               window.scrollTo(0, 0);
+               sessionStorage.setItem("visitedExperiences", "true");
+       }, []);
 
 	const currentSEO = SEO.find((item) => item.page === "experiences");
 

--- a/src/pages/homepage.jsx
+++ b/src/pages/homepage.jsx
@@ -30,10 +30,10 @@ const Homepage = () => {
                 window.scrollTo(0, 0);
         }, []);
 
-        useEffect(() => {
-                setProjectsUnlocked(localStorage.getItem("visitedProjects") === "true");
-                setExperiencesUnlocked(localStorage.getItem("visitedExperiences") === "true");
-        }, []);
+       useEffect(() => {
+               setProjectsUnlocked(sessionStorage.getItem("visitedProjects") === "true");
+               setExperiencesUnlocked(sessionStorage.getItem("visitedExperiences") === "true");
+       }, []);
 
 	useEffect(() => {
 		const handleScroll = () => {

--- a/src/pages/projects.jsx
+++ b/src/pages/projects.jsx
@@ -12,10 +12,10 @@ import SEO from "../data/seo";
 import "./styles/projects.css";
 
 const Projects = () => {
-        useEffect(() => {
-                window.scrollTo(0, 0);
-                localStorage.setItem("visitedProjects", "true");
-        }, []);
+       useEffect(() => {
+               window.scrollTo(0, 0);
+               sessionStorage.setItem("visitedProjects", "true");
+       }, []);
 
 	const currentSEO = SEO.find((item) => item.page === "projects");
 


### PR DESCRIPTION
## Summary
- reset experience/project locks on tab closure by using `sessionStorage`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860994c47648325b551d46828bd5a78