### PR TITLE
Fix homepage experience blur

### DIFF
--- a/src/components/homepage/styles/experience.css
+++ b/src/components/homepage/styles/experience.css
@@ -58,8 +58,9 @@
 }
 
 .homepage-experience.locked {
-        pointer-events: none;
-        filter: grayscale(100%) blur(3px);
+       pointer-events: none;
+       /* remove blur so the text and lock remain crisp */
+       filter: grayscale(100%);
 }
 
 .locked-overlay {


### PR DESCRIPTION
## Summary
- remove blur filter from locked experience cards so their text and lock icon remain sharp

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860abdf5c588325a61b9a8a4d604619