### PR TITLE
Add blur overlay for locked homepage experiences

### DIFF
--- a/src/components/homepage/experience.jsx
+++ b/src/components/homepage/experience.jsx
@@ -11,9 +11,9 @@ const Experience = (props) => {
 
 	return (
 		<React.Fragment>
-                        <div className="homepage-experience-wrapper">
-                                <div className={`homepage-experience${locked ? " locked" : ""}`}>
-                                        <div className="homepage-experience-content">
+                       <div className="homepage-experience-wrapper">
+                               <div className={`homepage-experience${locked ? " locked" : ""}`}>
+                                       <div className="homepage-experience-content">
 					<div className="homepage-experience-date">
 						|&nbsp;&nbsp;&nbsp;{date}
 					</div>
@@ -30,19 +30,19 @@ const Experience = (props) => {
                                                         />
                                                 </Link>
                                         </div>
-                                </div>
-                                {locked && (
-                                        <div className="locked-overlay">
-                                                <FontAwesomeIcon icon={faLock} className="lock-icon" />
-                                                {unlockMessage && (
-                                                        <div className="locked-text">{unlockMessage}</div>
-                                                )}
-                                        </div>
-                                )}
-                        </div>
-                        </div>
-                </React.Fragment>
-        );
+                                       </div>
+                               </div>
+                               {locked && (
+                                       <div className="locked-overlay">
+                                               <FontAwesomeIcon icon={faLock} className="lock-icon" />
+                                               {unlockMessage && (
+                                                       <div className="locked-text">{unlockMessage}</div>
+                                               )}
+                                       </div>
+                               )}
+                       </div>
+               </React.Fragment>
+       );
 };
 
 export default Experience;

--- a/src/components/homepage/styles/experience.css
+++ b/src/components/homepage/styles/experience.css
@@ -59,8 +59,7 @@
 
 .homepage-experience.locked {
        pointer-events: none;
-       /* remove blur so the text and lock remain crisp */
-       filter: grayscale(100%);
+       filter: grayscale(100%) blur(3px);
 }
 
 .locked-overlay {


### PR DESCRIPTION
## Summary
- update homepage experience layout so locked overlay sits outside content
- blur locked homepage experiences to match project lock style

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b068109483258d578ebf72eaa906