### PR TITLE
Fix homepage image alignment

### DIFF
--- a/src/pages/styles/homepage.css
+++ b/src/pages/styles/homepage.css
@@ -12,9 +12,9 @@
 }
 
 .homepage-first-area {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
+       display: flex;
+       justify-content: space-between;
+       align-items: flex-start;
 }
 
 .homepage-first-area-left-side {
@@ -144,4 +144,10 @@
                 flex-direction: column;
        }
 
+}
+
+@media (max-width: 600px) {
+       .homepage-image-container {
+               width: 80%;
+       }
 }


### PR DESCRIPTION
## Summary
- align homepage title and subtitle with image by top aligning the flex container
- make the homepage image responsive for smaller screens

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860b3fe0d38832585265dcf9eb854f1